### PR TITLE
Add DNS support

### DIFF
--- a/BruteShark/BruteSharkDesktop/MainForm.Designer.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.Designer.cs
@@ -35,12 +35,14 @@
             treeNode2});
             System.Windows.Forms.TreeNode treeNode4 = new System.Windows.Forms.TreeNode("Network Map");
             System.Windows.Forms.TreeNode treeNode5 = new System.Windows.Forms.TreeNode("Tcp Sessions");
-            System.Windows.Forms.TreeNode treeNode6 = new System.Windows.Forms.TreeNode("Network", new System.Windows.Forms.TreeNode[] {
+            System.Windows.Forms.TreeNode treeNode6 = new System.Windows.Forms.TreeNode("DNS");
+            System.Windows.Forms.TreeNode treeNode7 = new System.Windows.Forms.TreeNode("Network", new System.Windows.Forms.TreeNode[] {
             treeNode4,
-            treeNode5});
-            System.Windows.Forms.TreeNode treeNode7 = new System.Windows.Forms.TreeNode("Files");
-            System.Windows.Forms.TreeNode treeNode8 = new System.Windows.Forms.TreeNode("Data", new System.Windows.Forms.TreeNode[] {
-            treeNode7});
+            treeNode5,
+            treeNode6});
+            System.Windows.Forms.TreeNode treeNode8 = new System.Windows.Forms.TreeNode("Files");
+            System.Windows.Forms.TreeNode treeNode9 = new System.Windows.Forms.TreeNode("Data", new System.Windows.Forms.TreeNode[] {
+            treeNode8});
             this.mainSplitContainer = new System.Windows.Forms.SplitContainer();
             this.secondaryUpperSplitContainer = new System.Windows.Forms.SplitContainer();
             this.removeFilesButton = new System.Windows.Forms.Button();
@@ -313,16 +315,18 @@
             treeNode4.Text = "Network Map";
             treeNode5.Name = "SessionsNode";
             treeNode5.Text = "Tcp Sessions";
-            treeNode6.Name = "NetworkNode";
-            treeNode6.Text = "Network";
-            treeNode7.Name = "FilesNode";
-            treeNode7.Text = "Files";
-            treeNode8.Name = "DataNode";
-            treeNode8.Text = "Data";
+            treeNode6.Name = "DnsResponsesNode";
+            treeNode6.Text = "DNS";
+            treeNode7.Name = "NetworkNode";
+            treeNode7.Text = "Network";
+            treeNode8.Name = "FilesNode";
+            treeNode8.Text = "Files";
+            treeNode9.Name = "DataNode";
+            treeNode9.Text = "Data";
             this.modulesTreeView.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode3,
-            treeNode6,
-            treeNode8});
+            treeNode7,
+            treeNode9});
             this.modulesTreeView.Size = new System.Drawing.Size(228, 449);
             this.modulesTreeView.TabIndex = 0;
             this.modulesTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.modulesTreeView_AfterSelect);

--- a/BruteShark/BruteSharkDesktop/MainForm.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.cs
@@ -25,6 +25,7 @@ namespace BruteSharkDesktop
         private NetworkMapUserControl _networkMapUserControl;
         private SessionsExplorerUserControl _sessionsExplorerUserControl;
         private FilesUserControl _filesUserControl;
+        private DnsResponseUserControl _dnsResponseUserControl;
 
 
         public MainForm()
@@ -50,6 +51,8 @@ namespace BruteSharkDesktop
             _passwordsUserControl.Dock = DockStyle.Fill;
             _filesUserControl = new FilesUserControl();
             _filesUserControl.Dock = DockStyle.Fill;
+            _dnsResponseUserControl = new DnsResponseUserControl();
+            _dnsResponseUserControl.Dock = DockStyle.Fill;
 
             // Contract the events.
             _processor.UdpPacketArived += (s, e) => _analyzer.Analyze(Casting.CastProcessorUdpPacketToAnalyzerUdpPacket(e.Packet));
@@ -198,6 +201,12 @@ tshark -F pcap -r <pcapng file> -w <pcap file>";
                 _filesUserControl.AddFile(fileObject);
                 this.modulesTreeView.Nodes["DataNode"].Nodes["FilesNode"].Text = $"Files ({_filesUserControl.FilesCount})";
             }
+            else if (e.ParsedItem is PcapAnalyzer.DnsNameMapping)
+            {
+                var dnsResponse = e.ParsedItem as PcapAnalyzer.DnsNameMapping;
+                _dnsResponseUserControl.AddNameMapping(dnsResponse);
+                this.modulesTreeView.Nodes["NetworkNode"].Nodes["DnsResponsesNode"].Text = $"DNS Responses ({_dnsResponseUserControl.AnswerCount})";
+            }
         }
 
         private void addFilesButton_Click(object sender, EventArgs e)
@@ -257,6 +266,9 @@ tshark -F pcap -r <pcapng file> -w <pcap file>";
                     break;
                 case "FilesNode":
                     this.modulesSplitContainer.Panel2.Controls.Add(_filesUserControl);
+                    break;
+                case "DnsResponsesNode":
+                    this.modulesSplitContainer.Panel2.Controls.Add(_dnsResponseUserControl);
                     break;
                 default:
                     break;

--- a/BruteShark/BruteSharkDesktop/MainForm.cs
+++ b/BruteShark/BruteSharkDesktop/MainForm.cs
@@ -67,7 +67,14 @@ namespace BruteSharkDesktop
 
             InitilizeFilesIconsList();
             InitilizeModulesCheckedListBox();
+            InitilizeDnsPlumbing();
             this.modulesTreeView.ExpandAll();
+        }
+
+        private void InitilizeDnsPlumbing()
+        {
+            var dnsModule = _analyzer.AvailableModules.First(m => m.Name == "DNS") as PcapAnalyzer.DnsModule;
+            _networkMapUserControl.SetDns(dnsModule.Mappings);
         }
 
         private void InitilizeModulesCheckedListBox()

--- a/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.Designer.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.Designer.cs
@@ -1,0 +1,61 @@
+﻿namespace BruteSharkDesktop
+{
+    partial class DnsResponseUserControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.queriesDataGridView = new System.Windows.Forms.DataGridView();
+            ((System.ComponentModel.ISupportInitialize)(this.queriesDataGridView)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // queriesDataGridView
+            // 
+            this.queriesDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.queriesDataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.queriesDataGridView.Location = new System.Drawing.Point(0, 0);
+            this.queriesDataGridView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.queriesDataGridView.Name = "queriesDataGridView";
+            this.queriesDataGridView.Size = new System.Drawing.Size(461, 407);
+            this.queriesDataGridView.TabIndex = 0;
+            // 
+            // DnsResponseUserControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.queriesDataGridView);
+            this.Name = "DnsResponseUserControl";
+            this.Size = new System.Drawing.Size(461, 407);
+            ((System.ComponentModel.ISupportInitialize)(this.queriesDataGridView)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.DataGridView queriesDataGridView;
+    }
+}

--- a/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.cs
+++ b/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Text;
+using System.Windows.Forms;
+using PcapAnalyzer;
+
+namespace BruteSharkDesktop
+{
+    public partial class DnsResponseUserControl : UserControl
+    {
+        private BindingSource _queriesBindingSource;
+        public int AnswerCount => this.queriesDataGridView.RowCount;
+
+        public DnsResponseUserControl()
+        {
+            InitializeComponent();
+
+            // Initialize the answers gridview.
+            _queriesBindingSource = new BindingSource();
+            this.queriesDataGridView.DataSource = _queriesBindingSource;
+            this.queriesDataGridView.AllowUserToAddRows = false;
+        }
+
+        internal void AddNameMapping(DnsNameMapping mapping)
+        {
+            this.SuspendLayout();
+
+            _queriesBindingSource.Add(mapping);
+
+            this.ResumeLayout();
+        }
+    }
+}

--- a/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.resx
+++ b/BruteShark/BruteSharkDesktop/UserControls/DnsResponseControl/DnsResponseUserControl.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/BruteShark/PcapAnalyzer/Analyzer.cs
+++ b/BruteShark/PcapAnalyzer/Analyzer.cs
@@ -13,6 +13,7 @@ namespace PcapAnalyzer
 
         public List<string> AvailableModulesNames => _availbleModules.Select(m => m.Name).ToList();
         public List<string> LoadedModulesNames => _loadedModules.Select(m => m.Name).ToList();
+        public IEnumerable<IModule> AvailableModules => _availbleModules.ToList();
 
 
         public Analyzer()

--- a/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsModule.cs
+++ b/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsModule.cs
@@ -82,11 +82,6 @@ namespace PcapAnalyzer
         
         private void RaiseParsedItemDetected(string query, string destination)
         {
-            //if (_mappings.Any(m => m.Query == query && m.Destination == destination))
-            //{
-            //    return;
-            //}
-
             var response = new DnsNameMapping()
             {
                 Query = query,

--- a/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsModule.cs
+++ b/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsModule.cs
@@ -1,0 +1,116 @@
+﻿using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PcapAnalyzer
+{
+    public class DnsModule : IModule
+    {
+        public string Name => "DNS";
+
+        public event EventHandler<ParsedItemDetectedEventArgs> ParsedItemDetected;
+
+        private HashSet<DnsNameMapping> _mappings;
+
+        public HashSet<DnsNameMapping> Mappings => _mappings;
+
+        private DnsNameMappingComparer _comparer;
+
+        public DnsModule()
+        {
+            _mappings = new HashSet<DnsNameMapping>();
+            _comparer = new DnsNameMappingComparer();
+        }
+
+        public void Analyze(UdpPacket udpPacket)
+        {
+            //We are going to assume that all DNS traffic is on port 53
+            if (udpPacket.DestinationPort != 53 && udpPacket.SourcePort != 53)
+            {
+                return;
+            }
+
+            var header = Header.FromArray(udpPacket.Data);
+            if (header.Response == false)
+            {
+                //We don't care about non responses
+            }
+            else
+            {
+                var res = Response.FromArray(udpPacket.Data);
+
+                var answers = GetStringsForAnswers(res.AnswerRecords);
+                foreach (var answer in answers)
+                {
+                    //TODO: Probably should do this better...
+                    RaiseParsedItemDetected(res.Questions[0].Name.ToString(), answer);
+                }
+            }
+        }
+
+        private IEnumerable<string> GetStringsForAnswers(IList<IResourceRecord> answerRecords)
+        {
+            var returnList = new List<string>();
+            foreach (var ar in answerRecords)
+            {
+                if (ar is IPAddressResourceRecord)
+                {
+                    returnList.Add((ar as IPAddressResourceRecord).IPAddress.ToString());
+                }
+                else if (ar is CanonicalNameResourceRecord)
+                {
+                    returnList.Add((ar as CanonicalNameResourceRecord).CanonicalDomainName.ToString());
+                }
+                else if (ar is PointerResourceRecord)
+                {
+                    returnList.Add((ar as PointerResourceRecord).PointerDomainName.ToString());
+                }
+                else
+                {
+                    //Will show up obviously wrong in UX, need to decide which other queries are worthwhile to special case
+                    returnList.Add(ar.ToString());
+                }
+            }
+
+            return returnList;
+        }
+        
+        private void RaiseParsedItemDetected(string query, string destination)
+        {
+            //if (_mappings.Any(m => m.Query == query && m.Destination == destination))
+            //{
+            //    return;
+            //}
+
+            var response = new DnsNameMapping()
+            {
+                Query = query,
+                Destination = destination,
+            };
+
+            if (_mappings.Contains(response, _comparer))
+            {
+                return;
+            }
+
+            if (_mappings.Add(response))
+            {
+                this.ParsedItemDetected(this, new ParsedItemDetectedEventArgs()
+                {
+                    ParsedItem = response
+                });
+            }
+        }
+
+        public void Analyze(TcpPacket tcpPacket) { }
+
+        public void Analyze(TcpSession tcpSession) { }
+
+        public void Analyze(UdpStream udpStream) { }
+    }
+}

--- a/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsNameMapping.cs
+++ b/BruteShark/PcapAnalyzer/Modules/DnsModule/DnsNameMapping.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PcapAnalyzer
+{
+    public class DnsNameMapping
+    {
+        public DnsNameMapping()
+        {
+        }
+
+        public string Query { get; set; }
+        public string Destination { get; set; }
+    }
+
+    class DnsNameMappingComparer : IEqualityComparer<DnsNameMapping>
+    {
+        public bool Equals(DnsNameMapping x, DnsNameMapping y)
+        {
+            return x.Query == y.Query && x.Destination == y.Destination;
+        }
+
+        public int GetHashCode(DnsNameMapping obj)
+        {
+            return obj.Query.GetHashCode() ^ obj.Destination.GetHashCode();
+        }
+    }
+}

--- a/BruteShark/PcapAnalyzer/PcapAnalyzer.csproj
+++ b/BruteShark/PcapAnalyzer/PcapAnalyzer.csproj
@@ -3,10 +3,12 @@
   <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+   <UserSecretsId>323354f7-3e9f-4606-9a77-73084fa01769</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Asn1DotNet" Version="1.0.3" />
+    <PackageReference Include="DNS" Version="6.1.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Seeing a map of which nodes talked to which in a capture is useful, but those are just #'s... what if you could visualize which DNS names may have been queried for prior to the contacting a particular server?

Now there is a way:
![image](https://user-images.githubusercontent.com/11591952/100556380-bb47d780-3267-11eb-835d-61155919e3a3.png)
